### PR TITLE
Make rules for Apple silicon and universal binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,14 @@ build-zip:
 	mkdir -p releases/
 	zip releases/cert-monitor_linux_amd64.zip bin/cert-monitor_linux_amd64
 
-build-macos-intel:
+build-macos-universal: build-macos-amd64 build-macos-arm64
+	lipo -create -output bin/cert-monitor_darwin_universal bin/cert-monitor_darwin_amd64 bin/cert-monitor_darwin_arm64
+
+build-macos-amd64:
 	env GOOS=darwin GOARCH=amd64 CGO_ENABLED=0  go build -ldflags "${LD_FLAGS}" -o bin/cert-monitor_darwin_amd64 main.go 
 
-build-macos-arm:
+build-macos-arm64:
 	env GOOS=darwin GOARCH=arm64 CGO_ENABLED=0  go build -ldflags "${LD_FLAGS}" -o bin/cert-monitor_darwin_arm64 main.go 
 
 docker-build: 
 	docker build -t cert-monitor .
-


### PR DESCRIPTION
This PR adds Make rules for:
* darwin_arm64 (Apple silicon)
* Universal binary
 
Validation:
```
➜  cert-monitor git:(master) make build-macos-universal 
env GOOS=darwin GOARCH=amd64 CGO_ENABLED=0  go build -ldflags "-X main.GitCommit=3282554" -o bin/cert-monitor_darwin_amd64 main.go 
env GOOS=darwin GOARCH=arm64 CGO_ENABLED=0  go build -ldflags "-X main.GitCommit=3282554" -o bin/cert-monitor_darwin_arm64 main.go 
lipo -create -output bin/cert-monitor_darwin_universal bin/cert-monitor_darwin_amd64 bin/cert-monitor_darwin_arm64

➜  cert-monitor git:(master) file bin/cert-monitor_darwin_amd64 
bin/cert-monitor_darwin_amd64: Mach-O 64-bit executable x86_64

➜  cert-monitor git:(master) file bin/cert-monitor_darwin_arm64 
bin/cert-monitor_darwin_arm64: Mach-O 64-bit executable arm64

➜  cert-monitor git:(master) file bin/cert-monitor_darwin_universal 
bin/cert-monitor_darwin_universal: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64] [arm64]
bin/cert-monitor_darwin_universal (for architecture x86_64):	Mach-O 64-bit executable x86_64
bin/cert-monitor_darwin_universal (for architecture arm64):	Mach-O 64-bit executable arm64
```